### PR TITLE
Add switch statement indenting to eslintrc

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -121,7 +121,7 @@
 /**
  * Style
  */
-    "indent": [2, 2],                // http://eslint.org/docs/rules/indent
+    "indent": [2, 2, {"SwitchCase" : 1} ],  // http://eslint.org/docs/rules/indent
     "brace-style": [2,               // http://eslint.org/docs/rules/brace-style
       "1tbs", {
       "allowSingleLine": true


### PR DESCRIPTION
The sdk squad favors indentation on switch statements for better readability. Thoughts? 